### PR TITLE
Support for custom attributes and tags

### DIFF
--- a/Text/RSS/Conduit/Parse.hs
+++ b/Text/RSS/Conduit/Parse.hs
@@ -244,7 +244,7 @@ makeTraversals ''ChannelPiece
 -- | Parse an @\<rss\>@ element.
 rssDocument :: MonadThrow m => ConduitM Event o m (Maybe RssDocument)
 rssDocument = tagName' "rss" attributes $ \version -> force "Missing <channel>" $ tagIgnoreAttrs "channel" (manyYield' (choose piece) =$= parser version) <* many ignoreAnyTreeContent where
-  parser version = getZipConduit $ RssDocument version
+  parser version = getZipConduit $ RssDocument version [] -- NB: May want to parse attrs here. Unsure of the best way to approach this.
     <$> ZipConduit (projectC _ChannelTitle =$= headRequiredC "Missing <title> element")
     <*> ZipConduit (projectC _ChannelLink =$= headRequiredC "Missing <link> element")
     <*> ZipConduit (projectC _ChannelDescription =$= headDefC "")  -- Lenient

--- a/Text/RSS/Conduit/Render.hs
+++ b/Text/RSS/Conduit/Render.hs
@@ -44,10 +44,8 @@ import           URI.ByteString
 -- }}}
 
 -- | Render the top-level @\<rss\>@ element.
-renderRssDocument :: (Monad m) => Attributes -> RssDocument -> Source m Event
-renderRssDocument userAttrs d = 
-  let attrs = (attr "version" . pack . showVersion $ d^.documentVersionL) <> userAttrs in
-  tag "rss" attrs $
+renderRssDocument :: (Monad m) => RssDocument -> Source m Event
+renderRssDocument d = tag "rss" attrs $
   tag "channel" mempty $ do
     textTag "title" $ d^.channelTitleL
     textTag "link" $ renderRssURI $ d^.channelLinkL
@@ -69,6 +67,9 @@ renderRssDocument userAttrs d =
     renderRssSkipHours $ d^.channelSkipHoursL
     renderRssSkipDays $ d^.channelSkipDaysL
     forM_ (d^..channelItemsL) renderRssItem
+  where
+  versionAttr = (attr "version" . pack . showVersion $ d^.documentVersionL)
+  attrs = versionAttr <> map attr (d^.documentAttributesL)
 
 -- | Render an @\<item\>@ element.
 renderRssItem :: (Monad m) => RssItem -> Source m Event

--- a/Text/RSS/Conduit/Render.hs
+++ b/Text/RSS/Conduit/Render.hs
@@ -69,7 +69,7 @@ renderRssDocument d = tag "rss" attrs $
     forM_ (d^..channelItemsL) renderRssItem
   where
   versionAttr = (attr "version" . pack . showVersion $ d^.documentVersionL)
-  attrs = versionAttr <> map attr (d^.documentAttributesL)
+  attrs = versionAttr <> map (uncurry attr) (d^.documentAttributesL)
 
 -- | Render an @\<item\>@ element.
 renderRssItem :: (Monad m) => RssItem -> Source m Event

--- a/Text/RSS/Conduit/Render.hs
+++ b/Text/RSS/Conduit/Render.hs
@@ -72,11 +72,11 @@ renderRssDocument d = tag "rss" (attr "version" . pack . showVersion $ d^.docume
 renderRssItem :: (Monad m) => RssItem -> Source m Event
 renderRssItem i = tag "item" mempty $ do
   optionalTextTag "title" $ i^.itemTitleL
-  forM_ (i^.itemLinkL) $ textTag "link" . decodeUtf8 . withRssURI serializeURIRef'
+  forM_ (i^.itemLinkL) $ textTag "link" . renderRssURI
   optionalTextTag "description" $ i^.itemDescriptionL
   optionalTextTag "author" $ i^.itemAuthorL
   forM_ (i^..itemCategoriesL) renderRssCategory
-  forM_ (i^.itemCommentsL) $ textTag "comments" . decodeUtf8 . withRssURI serializeURIRef'
+  forM_ (i^.itemCommentsL) $ textTag "comments" . renderRssURI
   forM_ (i^..itemEnclosureL) renderRssEnclosure
   forM_ (i^.itemGuidL) renderRssGuid
   forM_ (i^.itemPubDateL) $ dateTag "pubDate"
@@ -84,18 +84,18 @@ renderRssItem i = tag "item" mempty $ do
 
 -- | Render a @\<source\>@ element.
 renderRssSource :: (Monad m) => RssSource -> Source m Event
-renderRssSource s = tag "source" (attr "url" $ decodeUtf8 $ withRssURI serializeURIRef' $ s^.sourceUrlL) . content $ s^.sourceNameL
+renderRssSource s = tag "source" (attr "url" $ renderRssURI $ s^.sourceUrlL) . content $ s^.sourceNameL
 
 -- | Render an @\<enclosure\>@ element.
 renderRssEnclosure :: (Monad m) => RssEnclosure -> Source m Event
 renderRssEnclosure e = tag "enclosure" attributes mempty where
-  attributes = attr "url" (decodeUtf8 $ withRssURI serializeURIRef' $ e^.enclosureUrlL)
+  attributes = attr "url" (renderRssURI $ e^.enclosureUrlL)
     <> attr "length" (tshow $ e^.enclosureLengthL)
     <> attr "type" (e^.enclosureTypeL)
 
 -- | Render a @\<guid\>@ element.
 renderRssGuid :: (Monad m) => RssGuid -> Source m Event
-renderRssGuid (GuidUri u) = tag "guid" (attr "isPermaLink" "true") $ content $ decodeUtf8 $ withRssURI serializeURIRef' u
+renderRssGuid (GuidUri u) = tag "guid" (attr "isPermaLink" "true") $ content $ renderRssURI u
 renderRssGuid (GuidText t) = tag "guid" mempty $ content t
 
 
@@ -132,9 +132,9 @@ renderRssCategory c = tag "category" (attr "domain" $ c^.categoryDomainL) . cont
 -- | Render an @\<image\>@ element.
 renderRssImage :: (Monad m) => RssImage -> Source m Event
 renderRssImage i = tag "image" mempty $ do
-  textTag "url" $ decodeUtf8 $ withRssURI serializeURIRef' $ i^.imageUriL
+  textTag "url" $ renderRssURI $ i^.imageUriL
   textTag "title" $ i^.imageTitleL
-  textTag "link" $ decodeUtf8 $ withRssURI serializeURIRef' $ i^.imageLinkL
+  textTag "link" $ renderRssURI $ i^.imageLinkL
   forM_ (i^.imageHeightL) $ textTag "height" . tshow
   forM_ (i^.imageWidthL) $ textTag "width" . tshow
   optionalTextTag "description" $ i^.imageDescriptionL
@@ -145,7 +145,7 @@ renderRssTextInput t = tag "textInput" mempty $ do
   textTag "title" $ t^.textInputTitleL
   textTag "description" $ t^.textInputDescriptionL
   textTag "name" $ t^.textInputNameL
-  textTag "link" $ decodeUtf8 $ withRssURI serializeURIRef' $ t^.textInputLinkL
+  textTag "link" $ renderRssURI $ t^.textInputLinkL
 
 -- | Render a @\<skipDays\>@ element.
 renderRssSkipDays :: (Monad m) => Set Day -> Source m Event
@@ -168,4 +168,6 @@ optionalTextTag name value = unless (onull value) $ textTag name value
 
 dateTag :: (Monad m) => Name -> UTCTime -> Source m Event
 dateTag name = tag name mempty . content . formatTimeRFC822 . utcToZonedTime utc
+
+renderRssURI = decodeUtf8 . withRssURI serializeURIRef'
 -- }}}

--- a/Text/RSS/Conduit/Render.hs
+++ b/Text/RSS/Conduit/Render.hs
@@ -44,8 +44,10 @@ import           URI.ByteString
 -- }}}
 
 -- | Render the top-level @\<rss\>@ element.
-renderRssDocument :: (Monad m) => RssDocument -> Source m Event
-renderRssDocument d = tag "rss" (attr "version" . pack . showVersion $ d^.documentVersionL) $
+renderRssDocument :: (Monad m) => Attributes -> RssDocument -> Source m Event
+renderRssDocument userAttrs d = 
+  let attrs = (attr "version" . pack . showVersion $ d^.documentVersionL) <> userAttrs in
+  tag "rss" attrs $
   tag "channel" mempty $ do
     textTag "title" $ d^.channelTitleL
     textTag "link" $ renderRssURI $ d^.channelLinkL

--- a/Text/RSS/Conduit/Render.hs
+++ b/Text/RSS/Conduit/Render.hs
@@ -69,7 +69,7 @@ renderRssDocument d = tag "rss" attrs $
     forM_ (d^..channelItemsL) renderRssItem
   where
   versionAttr = (attr "version" . pack . showVersion $ d^.documentVersionL)
-  attrs = versionAttr <> map (uncurry attr) (d^.documentAttributesL)
+  attrs = versionAttr <> foldMap (uncurry attr) (d^.documentAttributesL)
 
 -- | Render an @\<item\>@ element.
 renderRssItem :: (Monad m) => RssItem -> Source m Event

--- a/Text/RSS/Types.hs
+++ b/Text/RSS/Types.hs
@@ -48,6 +48,8 @@ import           GHC.Generics           hiding ((:+:))
 import           Text.Read
 
 import           URI.ByteString
+
+import           Text.XML               (Name)
 -- }}}
 
 
@@ -222,6 +224,7 @@ asDay t = maybe (throwM $ InvalidDay t) return . readMaybe $ unpack t
 -- | The @\<rss\>@ element.
 data RssDocument = RssDocument
   { documentVersion       :: Version
+  , documentAttributes    :: [(Name,Text)]
   , channelTitle          :: Text
   , channelLink           :: RssURI
   , channelDescription    :: Text

--- a/Text/RSS1/Conduit/Parse.hs
+++ b/Text/RSS1/Conduit/Parse.hs
@@ -210,6 +210,7 @@ data Rss1Document = Rss1Document Rss1Channel (Maybe RssImage) [RssItem] (Maybe R
 rss1ToRss2 :: Rss1Document -> RssDocument
 rss1ToRss2 (Rss1Document channel image items textInput) = RssDocument
   (Version [1] [])
+  []
   (channelTitle' channel)
   (channelLink' channel)
   (channelDescription' channel)


### PR DESCRIPTION
So if you take a look at http://www.rssboard.org/rss-profile there are a ton of different extension namespaces and tags that are strongly recommended. Even the W3C validator wants you to embed the atom namespace (see [here](https://validator.w3.org/feed/docs/warning/MissingAtomSelfLink.html)). 

This PR lets you embed attributes into the `<rss/>` tag. However, it does not (as yet) add support for parsing such attributes or for embedding custom tags corresponding to any namespaces added in the `<rss/>` tag.

What I did here is add a field to the `RssDocument` type. However, I'm not sure this is the best way to do things, since custom namespaces and tags are sort of an "open" set whereas this library is clearly trying to represent RSS documents as a "closed" set. So the way I see it, there are three ways of doing this:

1. 
* Add aditional arguments to `renderRssDocument` containing optional custom document attrs and tags, which will be included in the renderer's `Event` stream. 
* Optionally add additional return values to the `rssDocument` parser containing found non-standard attrs and tags. This might require passing a list of attrs to watch out for, since it looks like `Text.XML.Stream.Parse` doesn't let you grab any arbitrary tag without specifying its name in advance. 


2. Add additional fields to `RssDocument` containing e.g. a list of attributes (which I've done in this PR) and a list of tags (although the best way to type this is not immediately obvious to me).

3. Attempt to add explicit fields for every common namespace and tag. Might be a lot of work and isn't very future-proof.

I like option 1  since it's very clear that non-standard attrs and tags are "external" to this package and only handled in the abstract. However, it's unclear to me how the parser would work for such a thing. It would probably look something like 

```haskell
data Tag m = Tag Name Attributes (Source m Event) -- See Text.XML.Stream.Render.tag
renderRssDocument :: (Monad m) => [Attribute] -> [Tag m] -> RssDocument -> Source m Event
rssDocument :: MonadThrow m => [Name] -> [Name] -> ConduitM Event ? m ? -- unclear
rssDocument attrNames tagNames = ...
```

Option 2 *might* be more straightforward to write a parser for, but I'm not sure.

I'm not sure if option 3 is a good idea unless there was some way for users to extend it without modifying the library. Doing this right would probably require some kind of typeclass mechanism. However, practically speaking, adding a few fields for a few popular tags from http://www.rssboard.org/rss-profile (like "creator", "content", etc.) might be the best way to go.